### PR TITLE
fix: memory leaks and crash issue

### DIFF
--- a/Sources/SocketDataType.swift
+++ b/Sources/SocketDataType.swift
@@ -103,8 +103,10 @@ public extension SocketDataType {
         guard error == 0 else {
             throw SwiftAsyncSocketError.gaiError(code: error)
         }
+
+        let res0 = res
         defer {
-            freeaddrinfo(res)
+            freeaddrinfo(res0)
         }
 
         var address4: Data?

--- a/Sources/SwiftAsyncSocket/SwiftAsyncSocket.swift
+++ b/Sources/SwiftAsyncSocket/SwiftAsyncSocket.swift
@@ -17,6 +17,13 @@ struct SwiftAsyncSocketKeys {
     init() {}
 }
 
+class Weak<T: AnyObject> {
+    weak var value : T?
+    init (_ value: T?) {
+        self.value = value
+    }
+}
+
 public class SwiftAsyncSocket: NSObject {
 
     var flags: SwiftAsyncSocketFlags = []
@@ -88,7 +95,7 @@ public class SwiftAsyncSocket: NSObject {
 
     var lastSSLHandshakeError: OSStatus = 0
 
-    let queueKey: DispatchSpecificKey<SwiftAsyncSocket> = DispatchSpecificKey<SwiftAsyncSocket>()
+    let queueKey: DispatchSpecificKey<Weak<SwiftAsyncSocket>> = DispatchSpecificKey<Weak<SwiftAsyncSocket>>()
 
     var userDataStore: Any?
 
@@ -118,7 +125,7 @@ public class SwiftAsyncSocket: NSObject {
 
         super.init()
 
-        self.socketQueue.setSpecific(key: queueKey, value: self)
+        self.socketQueue.setSpecific(key: queueKey, value: Weak(self))
     }
 
     deinit {
@@ -127,9 +134,6 @@ public class SwiftAsyncSocket: NSObject {
         socketQueueDo {
             self.closeSocket(error: nil)
         }
-
-        delegate = nil
-        delegateQueue = nil
     }
 }
 // MARK: - init Function

--- a/Sources/SwiftAsyncSocket/SwiftAsyncSocketExtensions/Close/SwiftAsyncSocket+Close.swift
+++ b/Sources/SwiftAsyncSocket/SwiftAsyncSocketExtensions/Close/SwiftAsyncSocket+Close.swift
@@ -180,6 +180,9 @@ extension SwiftAsyncSocket {
         readSource?.cancel()
         writeSource?.cancel()
 
+        resumeReadSource()
+        resumeWriteSource()
+
         socket4FD = SwiftAsyncSocketKeys.socketNull
         socket6FD = SwiftAsyncSocketKeys.socketNull
         socketUN = SwiftAsyncSocketKeys.socketNull

--- a/Sources/SwiftAsyncSocket/SwiftAsyncSocketExtensions/PublicFiles/SwiftAsyncSocket+Advanced.swift
+++ b/Sources/SwiftAsyncSocket/SwiftAsyncSocketExtensions/PublicFiles/SwiftAsyncSocket+Advanced.swift
@@ -14,7 +14,7 @@ extension SwiftAsyncSocket {
      *  The same question maybe in the SwiftAsyncSocket is that the deadlock
      */
     public func markSocketQueue(newSocketQueue: DispatchQueue) {
-        newSocketQueue.setSpecific(key: queueKey, value: self)
+        newSocketQueue.setSpecific(key: queueKey, value: Weak(self))
     }
 
     public func unmarkSocketQueue(oldSocketQueue: DispatchQueue) {

--- a/Sources/SwiftAsyncUDPSocket/SwiftAsyncUDPSocket.swift
+++ b/Sources/SwiftAsyncUDPSocket/SwiftAsyncUDPSocket.swift
@@ -62,7 +62,7 @@ public class SwiftAsyncUDPSocket: NSObject {
 
     var cachedConnectedAddressStore: SwiftAsyncUDPSocketAddress?
 
-    var queueKey: DispatchSpecificKey<SwiftAsyncUDPSocket> = DispatchSpecificKey<SwiftAsyncUDPSocket>()
+    var queueKey: DispatchSpecificKey<Weak<SwiftAsyncUDPSocket>> = DispatchSpecificKey<Weak<SwiftAsyncUDPSocket>>()
 
     var userDataStore: Any?
 
@@ -86,7 +86,7 @@ public class SwiftAsyncUDPSocket: NSObject {
         }
         super.init()
 
-        self.socketQueue.setSpecific(key: queueKey, value: self)
+        self.socketQueue.setSpecific(key: queueKey, value: Weak(self))
 
         #if os(iOS)
         NotificationCenter.default.addObserver(self,
@@ -103,9 +103,6 @@ public class SwiftAsyncUDPSocket: NSObject {
         socketQueueDo {
             self.close(error: nil)
         }
-
-        delegate = nil
-        delegateQueue = nil
     }
 
     @objc func applicationWillEnterForeGround() {

--- a/Sources/SwiftAsyncUDPSocket/SwiftAsyncUDPSocketExtensions/Sending/SwiftAsyncUDPSocket+Sending.swift
+++ b/Sources/SwiftAsyncUDPSocket/SwiftAsyncUDPSocketExtensions/Sending/SwiftAsyncUDPSocket+Sending.swift
@@ -241,7 +241,7 @@ extension SwiftAsyncUDPSocket {
     }
 
     func createSocket(IPv4: Bool, IPv6: Bool) throws {
-        assert(DispatchQueue.getSpecific(key: queueKey) == self, "Must be dispatched on socketQueue")
+        assert(DispatchQueue.getSpecific(key: queueKey)?.value == self, "Must be dispatched on socketQueue")
         assert(!flags.contains(.didCreatSockets), "Sockets have already been created")
 
         if IPv4 {
@@ -271,7 +271,7 @@ extension SwiftAsyncUDPSocket {
     }
 
     private func createSocket(domain: Int32) throws -> Int32 {
-        assert(DispatchQueue.getSpecific(key: queueKey) == self, "Must be dispatched on socketQueue")
+        assert(DispatchQueue.getSpecific(key: queueKey)?.value == self, "Must be dispatched on socketQueue")
 
         let socketFD = Darwin.socket(domain, SOCK_DGRAM, 0)
 


### PR DESCRIPTION
memory leaks:
- replaced the strong reference with weak reference for socket queue specific context;
- freeaddrinfo was called with invalidate pointer address;

crash issues:
- suspended read and write dispatch sources need to be resumed before dispatch queue deallocation;
- delegate and delegateQueue setters cannot be called during deallocation;